### PR TITLE
Fix build compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ optional arguments:
                         squad build to compare to
 ```
 
-#### Comparing a build to itself should return zero changes.
+#### Comparing a build to itself should return zero changes
 
 ```
 ❯ pipenv run ./squad-list-changes --group=lkft --project=linux-next-master-sanity --build=next-20211020 --base-build=next-20211020
 []
 ```
 
-#### Given a collection of changes, get a subset that contains only the regressions
+#### Given a collection of changes, get a subset that contains only regressions
 
 ```
 ❯ pipenv run ./squad-list-changes --group=lkft --project=linux-next-master-sanity --build=next-20211020 --base-build=next-20211019 > changes.json
 
-❯ jq '.[] | select(.change=="regression")' changes.json
+❯ jq '.[] | select(.change=="regression")' changes.json | jq --slurp
 ```
 
 ### `squad-list-results`: Get all of the results for a build

--- a/squad-list-changes
+++ b/squad-list-changes
@@ -65,7 +65,7 @@ def run():
         logger.error(f"Get base build failed. Build not found: '{args.base_build}'.")
         return -1
 
-    changes = project.compare_builds(base_build.id, build.id, True)
+    changes = project.compare_builds(base_build.id, build.id, force=True)
     regressions = changes["regressions"]
     if not regressions:
         logger.debug("No regressions found.")


### PR DESCRIPTION
    squad-list-changes: fix the arguments for comparing builds

    Due to changes in squad-client, one of the arguments must use its
    argument name with the value.

    Signed-off-by: Justin Cook <justin.cook@linaro.org>

    readme: make the readme more consistent for squad-list-changes

    Signed-off-by: Justin Cook <justin.cook@linaro.org>