### PR TITLE
all: get the kernel configs for a build test

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,5 +5,6 @@ name = "pypi"
 
 [packages]
 squad-client = "*"
+pyyaml = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7c3da75a59c5d9a8d46f9263712697731473956276463114050c3b0362364a80"
+            "sha256": "491faee25c1f4e64fe1c2298a9256b153fbca9278ff2d7dbdbe9b344851d321f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -61,11 +61,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:735e240d9a8506778cd7a453d97e817e536bb1fc29f4f6961ce297b9c7a917b0",
+                "sha256:83fcdeb225499d6344c8f7f34684c2981270beacc32ede2e669e94f7fa544405"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
+            "version": "==2.0.8"
         },
         "decorator": {
             "hashes": [
@@ -85,11 +85,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:4f69d7423a5a1972f6347ff233e38bbf4df6a150ef20fbb00c635442ac3060aa",
-                "sha256:a658beaf856ce46bc453366d5dc6b2ddc6c481efd3540cb28aa3943819caac9f"
+                "sha256:c8f3e07aefb9cf9e067f39686f035ce09b27a1ee602116a3030b91b6fc138ee4",
+                "sha256:d41f8e80b99690122400f9b2069b12f670246a1b4cc5d332bd6c4e2500e6d6fb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.29.0"
+            "version": "==7.30.0"
         },
         "jedi": {
             "hashes": [
@@ -223,11 +223,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72",
-                "sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170"
+                "sha256:5f29d62cb7a0ecacfa3d8ceea05a63cd22500543472d64298fc06ddda906b25d",
+                "sha256:7053aba00895473cb357819358ef33f11aa97e4ac83d38efb123e5649ceeecaf"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.22"
+            "version": "==3.0.23"
         },
         "ptyprocess": {
             "hashes": [
@@ -307,7 +307,7 @@
                 "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
                 "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==6.0"
         },
         "requests": {
@@ -328,11 +328,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:157d21de9d055ab9e8ea3186d91e7f4f865e11f42deafa952d90842671fc2576",
-                "sha256:4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d"
+                "sha256:b4c634615a0cf5b02cf83c7bedffc8da0ca439f00e79452699454da6fbd4153d",
+                "sha256:feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==59.2.0"
+            "version": "==59.4.0"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -124,6 +124,72 @@ optional arguments:
 ❯ jq '.[] | select(.result>0.0)' results.json | jq --slurp
 ```
 
+### `get-kconfig`: Get all of the kernel configs for a build test
+
+```
+❯ pipenv run ./get-kconfig --help
+usage: get-kconfig [-h] --tuxconfig TUXCONFIG --name NAME
+
+List all kernel configs for a build test
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --tuxconfig TUXCONFIG
+                        tuxconfig yaml
+  --name NAME           test name
+```
+
+- Note: More than one result may be returned. Multiple architectures can use the same toolchain and kernel configs.
+- Note: Make variables are not used to generate the hash.
+
+```
+❯ pipenv run ./get-kconfig --tuxconfig=tuxconfig.yml --name=clang-12-defconfig-b9979cfa
+```
+
+```
+[
+  {
+    "name": "clang-12-defconfig-b9979cfa",
+    "set": "i386-clang-12",
+    "build": {
+      "target_arch": "i386",
+      "toolchain": "clang-12",
+      "kconfig": [
+        "defconfig",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft-crypto.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/distro-overrides.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/systemd.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/virtio.config",
+        "CONFIG_IGB=y",
+        "CONFIG_UNWINDER_FRAME_POINTER=y"
+      ]
+    }
+  },
+  {
+    "name": "clang-12-defconfig-b9979cfa",
+    "set": "x86-clang-12",
+    "build": {
+      "target_arch": "x86_64",
+      "toolchain": "clang-12",
+      "make_variables": {
+        "LLVM_IAS": 0
+      },
+      "kconfig": [
+        "defconfig",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/lkft-crypto.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/distro-overrides.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/systemd.config",
+        "https://raw.githubusercontent.com/Linaro/meta-lkft/sumo/recipes-kernel/linux/files/virtio.config",
+        "CONFIG_IGB=y",
+        "CONFIG_UNWINDER_FRAME_POINTER=y"
+      ]
+    }
+  }
+]
+```
+
 ## Contributing
 
 This (alpha) project is managed on [`github`](https://github.com) at https://github.com/Linaro/squad-client-utils

--- a/get-kconfig
+++ b/get-kconfig
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+import yaml
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def arg_parser():
+    parser = argparse.ArgumentParser(description="List all kernel configs for a build test")
+
+    parser.add_argument(
+        "--tuxconfig",
+        required=True,
+        help="tuxconfig yaml",
+    )
+
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="test name",
+    )
+
+    return parser
+
+def test_name(kconfig, toolchain):
+    if len(kconfig[1:]):
+        kconfig_hash = "%s-%s" % (
+            kconfig[0],
+            hashlib.sha1(json.dumps(kconfig[1:]).encode()).hexdigest()[0:8],
+        )
+    else:
+        kconfig_hash = kconfig[0]
+
+    return "%s-%s" % (toolchain, kconfig_hash)
+
+def run():
+    args = arg_parser().parse_args()
+
+    with open(args.tuxconfig, "r") as tuxconfig_yaml:
+        tc = yaml.safe_load(tuxconfig_yaml)
+
+    flat = []
+    for sset in tc["sets"]:
+        for build in sset["builds"]:
+            if type(build["kconfig"]) == list:
+                if args.name == test_name(build["kconfig"], build["toolchain"]):
+                    flat.append({
+                        "name": args.name,
+                        "set": sset["name"],
+                        "build": build,
+                    })
+
+    print(json.dumps(flat,indent=2))
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
When multiple kernel configs are used, we generate a hash from them to
add to the test name.

Given a tuxsuite yaml config, we can recreate that hash and print the
kernel configs for that test.

Signed-off-by: Justin Cook <justin.cook@linaro.org>