### PR TITLE
Script and functions for pulling LTP reproducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,39 @@ optional arguments:
 ❯ jq '.[] | select(.result>0.0)' results.json | jq --slurp
 ```
 
+### `squad-create-reproducer`: Get a reproducer for a given group, project, device and suite.
+
+This script gets a recent TuxRun reproducer from SQUAD for a chosen suite. When
+a reproducer is found, this is saved to a file and written to stdout.
+
+```
+./squad-create-reproducer --help
+usage: squad-create-reproducer [-h] --device-name DEVICE_NAME --group GROUP --project
+                               PROJECT --suite-name SUITE_NAME
+                               [--build-names BUILD_NAMES [BUILD_NAMES ...]] [--debug]
+                               [--filename FILENAME]
+                               [--search-build-count SEARCH_BUILD_COUNT]
+
+Get the latest TuxRun reproducer for a given group, project, device and suite. The
+reproducer will be printed to the terminal and written to a file.
+
+options:
+  -h, --help            show this help message and exit
+  --device-name DEVICE_NAME
+                        The device name (for example, qemu-arm64).
+  --group GROUP         The name of the SQUAD group.
+  --project PROJECT     The name of the SQUAD project.
+  --suite-name SUITE_NAME
+                        The suite name to grab a reproducer for.
+  --build-names BUILD_NAMES [BUILD_NAMES ...]
+                        The list of accepted build names (for example, gcc-12-lkftconfig).
+                        Regex is supported.
+  --debug               Display debug messages.
+  --filename FILENAME   Name for the reproducer file, 'reproducer' by default.
+  --search-build-count SEARCH_BUILD_COUNT
+                        The number of builds to fetch when searching for a reproducer.
+```
+
 ## Contributing
 
 This (alpha) project is managed on [`github`](https://github.com) at https://github.com/Linaro/squad-client-utils

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ a reproducer is found, this is saved to a file and written to stdout.
 ```
 ./squad-create-reproducer --help
 usage: squad-create-reproducer [-h] --device-name DEVICE_NAME --group GROUP --project
-                               PROJECT --suite-name SUITE_NAME
+                               PROJECT --suite-name SUITE_NAME [--allow-unfinished]
                                [--build-names BUILD_NAMES [BUILD_NAMES ...]] [--debug]
                                [--filename FILENAME]
                                [--search-build-count SEARCH_BUILD_COUNT]
@@ -209,6 +209,8 @@ options:
   --project PROJECT     The name of the SQUAD project.
   --suite-name SUITE_NAME
                         The suite name to grab a reproducer for.
+  --allow-unfinished    Allow fetching of reproducers where the build is marked as
+                        unfinished.
   --build-names BUILD_NAMES [BUILD_NAMES ...]
                         The list of accepted build names (for example, gcc-12-lkftconfig).
                         Regex is supported.

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -54,6 +54,13 @@ def parse_args(raw_args):
     )
 
     parser.add_argument(
+        "--allow-unfinished",
+        action="store_true",
+        default=False,
+        help="Allow fetching of reproducers where the build is marked as unfinished.",
+    )
+
+    parser.add_argument(
         "--build-names",
         required=False,
         default=["gcc-12-lkftconfig"],
@@ -99,6 +106,7 @@ def run(raw_args=None):
             args.suite_name,
             args.search_build_count,
             args.filename,
+            args.allow_unfinished,
         )
         reproducer_txt = pathlib.Path(tuxrun_reproducer_file).read_text(
             encoding="utf-8"

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -1,0 +1,115 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+
+import argparse
+import logging
+import os
+import pathlib
+import sys
+
+from squad_client.core.api import SquadApi
+
+import squadutilslib
+
+squad_host_url = "https://qa-reports.linaro.org/"
+SquadApi.configure(cache=3600, url=os.getenv("SQUAD_HOST", squad_host_url))
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def parse_args(raw_args):
+    parser = argparse.ArgumentParser(
+        description="Get the latest TuxRun reproducer for a given group, project, device and suite. The reproducer will be printed to the terminal and written to a file."
+    )
+
+    parser.add_argument(
+        "--device-name",
+        required=True,
+        help="The device name (for example, qemu-arm64).",
+    )
+
+    parser.add_argument(
+        "--group",
+        required=True,
+        help="The name of the SQUAD group.",
+    )
+
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="The name of the SQUAD project.",
+    )
+
+    parser.add_argument(
+        "--suite-name",
+        required=True,
+        help="The suite name to grab a reproducer for.",
+    )
+
+    parser.add_argument(
+        "--build-names",
+        required=False,
+        default=["gcc-12-lkftconfig"],
+        nargs="+",
+        help="The list of accepted build names (for example, gcc-12-lkftconfig). Regex is supported.",
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Display debug messages.",
+    )
+
+    parser.add_argument(
+        "--filename",
+        required=False,
+        default="reproducer",
+        help="Name for the reproducer file, 'reproducer' by default.",
+    )
+
+    parser.add_argument(
+        "--search-build-count",
+        required=False,
+        default=10,
+        type=int,
+        help="The number of builds to fetch when searching for a reproducer.",
+    )
+
+    return parser.parse_args(raw_args)
+
+
+def run(raw_args=None):
+    args = parse_args(raw_args)
+
+    try:
+        tuxrun_reproducer_file = squadutilslib.get_reproducer(
+            args.group,
+            args.project,
+            args.device_name,
+            args.debug,
+            args.build_names,
+            args.suite_name,
+            args.search_build_count,
+            args.filename,
+        )
+        reproducer_txt = pathlib.Path(tuxrun_reproducer_file).read_text(
+            encoding="utf-8"
+        )
+        print(reproducer_txt)
+    except squadutilslib.ReproducerNotFound as e:
+        logger.warning(
+            f"No reproducer could be found for {args.group} {args.project} {args.device_name} {args.build_names}"
+        )
+        logger.warning(f"{e}")
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+
+import logging
+import os
+import re
+from pathlib import Path
+
+import requests
+from requests import HTTPError
+from squad_client.core.models import Build, Squad, TestRun
+from squad_client.shortcuts import download_tests
+from squad_client.utils import first, getid
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class ReproducerNotFound(Exception):
+    """
+    Raised when no reproducer can be found.
+    """
+
+    def __init__(self, message="No reproducer found"):
+        super().__init__(message)
+
+
+def get_file(path, filename=None):
+    """
+    Download file if a URL is passed in, then return the filename of the
+    downloaded file. If an existing file path is passed in, return the path. If
+    a non-existent path is passed in, raise an exception.
+    """
+    logger.info(f"Getting file from {path}")
+    if re.search(r"https?://", path):
+        request = requests.get(path, allow_redirects=True)
+        request.raise_for_status()
+        if not filename:
+            filename = path.split("/")[-1]
+        else:
+            output_file = Path(filename)
+            output_file.parent.mkdir(exist_ok=True, parents=True)
+
+        with open(filename, "wb") as f:
+            f.write(request.content)
+        return filename
+    elif os.path.exists(path):
+        return path
+    else:
+        raise Exception(f"Path {path} not found")
+
+
+def find_first_good_testrun(
+    build_names, builds, suite_names, envs, project, output_filename="result.txt"
+):
+    """
+    Given a list of builds IDs to choose from in a project, find the first one
+    that has a match for the build name, suite names and environments
+    """
+
+    # Given a list of builds IDs, find one that contains the suites and that
+    # has a matching build name
+    for build in builds.values():
+        suites = []
+        # only pick builds that are finished
+        if not build.finished:
+            logger.info(f"Skipping {build.id} as build is not marked finished")
+            continue
+        logger.info(f"Checking build {build.id}")
+        # Create the list of suite IDs from the suite names
+        if suite_names:
+            for s in suite_names:
+                suites += project.suites(slug=s).values()
+
+        if os.path.exists(output_filename):
+            os.remove(output_filename)
+
+        # Use download_tests to gather filtered test results (build_name does not
+        # currently work as a filter)
+        download_tests(
+            project,
+            build,
+            envs,
+            suites,
+            "{test.test_run.metadata.build_name}/{test.test_run.id}",
+            output_filename,
+        )
+
+        # Look in the file that contains the downloaded tests and see if there is a
+        # match for one of the desired build_names
+        file_open = open(output_filename, "r")
+        file_lines = file_open.readlines()
+
+        for line in file_lines:
+            build_name, run_id = line.split("/")
+            for allowed_build_name in build_names:
+                re_match = re.match(f"^{allowed_build_name}$", build_name)
+                if re_match:
+                    # Return a TestRun with a matching build name, project, environment, suite
+                    # if it exists
+                    return TestRun(run_id)
+
+    # If no matching testrun found
+    return None
+
+
+def get_reproducer(
+    group, project, device_name, debug, build_names, suite_name, count, filename
+):
+    """
+    Given a group, project, device and accepted build names, return a
+    reproducer for a test run that meets these conditions.
+    """
+    if debug:
+        logger.setLevel(level=logging.DEBUG)
+
+    base_group = Squad().group(group)
+    if base_group is None:
+        logger.error(f"Get group failed. Group not found: {group}")
+        raise ReproducerNotFound
+
+    base_project = base_group.project(project)
+    if base_project is None:
+        logger.error(f"Get project failed. project not found: {project}")
+        raise ReproducerNotFound
+
+    logger.debug(f"build name {build_names}")
+
+    metadata = first(Squad().suitemetadata(suite=suite_name, kind="test"))
+
+    if metadata is None:
+        logger.error(f"There is no suite named: {suite_name}")
+        raise ReproducerNotFound
+
+    # == get a build that contains a run of the specified suite ==
+
+    # Get the latest N builds in the project so we don't pick something old
+    builds = base_project.builds(count=count, ordering="-id")
+    environment = base_project.environment(device_name)
+
+    logger.debug("Find build")
+    testrun = find_first_good_testrun(
+        build_names, builds, [suite_name], [environment], base_project
+    )
+
+    # Get the reproducer if a testrun is found
+    if testrun:
+        logger.info(
+            f"Found testrun {testrun} with build_name {testrun.metadata.build_name}, url: {testrun.url}"
+        )
+
+        # In theory there should only be one of those
+        logger.debug(f"Testrun id: {testrun.id}")
+
+        try:
+            tuxrun = get_file(f"{testrun.job_url}/reproducer", filename=filename)
+        except HTTPError:
+            logger.error(f"Reproducer not found at {testrun.job_url}!")
+            raise ReproducerNotFound
+        return tuxrun
+    else:
+        raise ReproducerNotFound

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -57,7 +57,13 @@ def get_file(path, filename=None):
 
 
 def find_first_good_testrun(
-    build_names, builds, suite_names, envs, project, output_filename="result.txt"
+    build_names,
+    builds,
+    suite_names,
+    envs,
+    project,
+    allow_unfinished=False,
+    output_filename="result.txt",
 ):
     """
     Given a list of builds IDs to choose from in a project, find the first one
@@ -68,8 +74,9 @@ def find_first_good_testrun(
     # has a matching build name
     for build in builds.values():
         suites = []
-        # only pick builds that are finished
-        if not build.finished:
+        # Only pick builds that are finished, unless we specify that unfinished
+        # builds are allowed
+        if not build.finished and not allow_unfinished:
             logger.info(f"Skipping {build.id} as build is not marked finished")
             continue
         logger.info(f"Checking build {build.id}")
@@ -111,7 +118,15 @@ def find_first_good_testrun(
 
 
 def get_reproducer(
-    group, project, device_name, debug, build_names, suite_name, count, filename
+    group,
+    project,
+    device_name,
+    debug,
+    build_names,
+    suite_name,
+    count,
+    filename,
+    allow_unfinished=False,
 ):
     """
     Given a group, project, device and accepted build names, return a
@@ -145,8 +160,9 @@ def get_reproducer(
     environment = base_project.environment(device_name)
 
     logger.debug("Find build")
+
     testrun = find_first_good_testrun(
-        build_names, builds, [suite_name], [environment], base_project
+        build_names, builds, [suite_name], [environment], base_project, allow_unfinished
     )
 
     # Get the reproducer if a testrun is found


### PR DESCRIPTION
These patches create a script, functions and the related documentation for pulling existing reproducers for TuxRun.

This will later be extended to pulling reproducers for running custom commands and creating TuxPlan reproducers.