### PR TITLE
Add support for creating reproducers for the LTP skipfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,45 @@ options:
                         The number of builds to fetch when searching for a reproducer.
 ```
 
+### `squad-create-skipfile-reproducers`: Creating skipfile reproducers
+
+The `squad-create-skipfile-reproducers` script can be used to create TuxRun or
+TuxPlan reproducers for the LTP skipfile.
+
+```
+./squad-create-skipfile-reproducers --help
+usage: squad-create-skipfile-reproducers [-h] --group GROUP [--allow-unfinished]
+                                         [--projects PROJECTS [PROJECTS ...]]
+                                         [--build-names BUILD_NAMES [BUILD_NAMES ...]]
+                                         [--debug]
+                                         [--device-names DEVICE_NAMES [DEVICE_NAMES ...]]
+                                         [--local] [--count COUNT]
+                                         [--skipfile-url SKIPFILE_URL]
+                                         [--suite-name SUITE_NAME]
+
+Produce TuxRun or TuxPlan reproducers for the LTP skipfile.
+
+options:
+  -h, --help            show this help message and exit
+  --group GROUP         The name of the SQUAD group.
+  --allow-unfinished    Allow fetching of reproducers where the build is marked as
+                        unfinished.
+  --projects PROJECTS [PROJECTS ...]
+                        A list of SQUAD projects to be tested.
+  --build-names BUILD_NAMES [BUILD_NAMES ...]
+                        The list of accepted build names (for example,
+                        gcc-12-lkftconfig). Regex is supported.
+  --debug               Display debug messages.
+  --device-names DEVICE_NAMES [DEVICE_NAMES ...]
+                        The list of device names (for example, qemu-arm64).
+  --local               Create a TuxRun reproducer when updating rather than a TuxPlan.
+  --count COUNT         The number of builds to fetch when searching for a reproducer.
+  --skipfile-url SKIPFILE_URL
+                        URL of the skipfile to test.
+  --suite-name SUITE_NAME
+                        The suite name to grab a reproducer for.
+```
+
 ## Contributing
 
 This (alpha) project is managed on [`github`](https://github.com) at https://github.com/Linaro/squad-client-utils

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -7,26 +7,26 @@
 # SPDX-License-Identifier: MIT
 
 
-import argparse
-import logging
-import os
-import pathlib
-import sys
+from argparse import ArgumentParser
+from logging import INFO, basicConfig, getLogger
+from os import chmod, getenv
+from pathlib import Path
 from stat import S_IRUSR, S_IWUSR, S_IXUSR
+from sys import exit
 
 from squad_client.core.api import SquadApi
 
-import squadutilslib
+from squadutilslib import ReproducerNotFound, create_custom_reproducer, get_reproducer
 
 squad_host_url = "https://qa-reports.linaro.org/"
-SquadApi.configure(cache=3600, url=os.getenv("SQUAD_HOST", squad_host_url))
+SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+basicConfig(level=INFO)
+logger = getLogger(__name__)
 
 
 def parse_args(raw_args):
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description="Get the latest TuxRun reproducer for a given group, project, device and suite."
         + " The reproducer will be printed to the terminal and written to a file."
         + " Optionally update the TuxRun reproducer to run custom commands and/or run in the cloud with TuxTest."
@@ -116,7 +116,7 @@ def run(raw_args=None):
     args = parse_args(raw_args)
 
     try:
-        reproducer_file = squadutilslib.get_reproducer(
+        reproducer_file = get_reproducer(
             args.group,
             args.project,
             args.device_name,
@@ -128,7 +128,7 @@ def run(raw_args=None):
             args.allow_unfinished,
             args.local,
         )
-    except squadutilslib.ReproducerNotFound as e:
+    except ReproducerNotFound as e:
         logger.error(
             f"No reproducer could be found for {args.group} {args.project} {args.device_name} {args.build_names}"
         )
@@ -136,7 +136,7 @@ def run(raw_args=None):
         return -1
 
     if args.custom_command:
-        reproducer_file = squadutilslib.create_custom_reproducer(
+        reproducer_file = create_custom_reproducer(
             reproducer_file,
             args.suite_name,
             args.custom_command,
@@ -144,14 +144,14 @@ def run(raw_args=None):
             args.filename,
         )
 
-    reproducer = pathlib.Path(reproducer_file).read_text(encoding="utf-8")
+    reproducer = Path(reproducer_file).read_text(encoding="utf-8")
 
     print(reproducer)
 
     # Make the script executable
-    os.chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
+    chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
     logger.info(f"file created: {reproducer_file}")
 
 
 if __name__ == "__main__":
-    sys.exit(run())
+    exit(run())

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -116,7 +116,7 @@ def run(raw_args=None):
     args = parse_args(raw_args)
 
     try:
-        reproducer_file = get_reproducer(
+        reproducer = get_reproducer(
             args.group,
             args.project,
             args.device_name,
@@ -136,21 +136,19 @@ def run(raw_args=None):
         return -1
 
     if args.custom_command:
-        reproducer_file = create_custom_reproducer(
-            reproducer_file,
+        reproducer = create_custom_reproducer(
+            reproducer,
             args.suite_name,
             args.custom_command,
-            args.local,
             args.filename,
+            args.local,
         )
-
-    reproducer = Path(reproducer_file).read_text(encoding="utf-8")
 
     print(reproducer)
 
     # Make the script executable
-    chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
-    logger.info(f"file created: {reproducer_file}")
+    chmod(args.filename, S_IXUSR | S_IRUSR | S_IWUSR)
+    logger.info(f"file created: {args.filename}")
 
 
 if __name__ == "__main__":

--- a/squad-create-skipfile-reproducers
+++ b/squad-create-skipfile-reproducers
@@ -21,6 +21,7 @@ from squadutilslib import (
     ReproducerNotFound,
     create_custom_reproducer,
     create_ltp_custom_command,
+    create_tuxsuite_plan_from_tuxsuite_tests,
     get_file,
     get_reproducer,
 )
@@ -110,6 +111,13 @@ def parse_args(raw_args):
         action="extend",
         nargs="+",
         help="The list of device names (for example, qemu-arm64).",
+    )
+    parser.add_argument(
+        "--local",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Create a TuxRun reproducer when updating rather than a TuxPlan.",
     )
 
     parser.add_argument(
@@ -202,7 +210,7 @@ def run(raw_args=None):
                     args.count,
                     tmp_custom_reproducer_filename,
                     args.allow_unfinished,
-                    local=True,
+                    local=args.local,
                 )
             except ReproducerNotFound:
                 logger.error(
@@ -218,7 +226,7 @@ def run(raw_args=None):
                         args.suite_name,
                         custom_command,
                         tmp_custom_reproducer_filename,
-                        local=True,
+                        local=args.local,
                     )
                     if not Path(reproducer_script_name).exists():
                         reproducer_scripts.append(reproducer_script_name)
@@ -232,6 +240,19 @@ def run(raw_args=None):
 
         if Path(tmp_custom_reproducer_filename).exists():
             Path.unlink(Path(tmp_custom_reproducer_filename))
+
+    if not args.local:
+        reproducer_scripts_tuxplan = []
+        # Convert tuxtest reproducers to tuxplans
+        for reproducer_script_name in reproducer_scripts:
+            plan_name = f"{reproducer_script_name}-plan.yaml"
+            reproducer = create_tuxsuite_plan_from_tuxsuite_tests(
+                reproducer_script_name,
+                plan_name=plan_name,
+            )
+            reproducer_scripts_tuxplan.append(plan_name)
+            Path.unlink(Path(reproducer_script_name))
+        reproducer_scripts = reproducer_scripts_tuxplan
 
     logger.info(
         "Finished creating skipfile reproducers. Files created: %s",

--- a/squad-create-skipfile-reproducers
+++ b/squad-create-skipfile-reproducers
@@ -1,0 +1,244 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+from argparse import ArgumentParser
+from logging import INFO, basicConfig, getLogger
+from os import getenv
+from pathlib import Path
+from re import findall, match
+from sys import exit
+from time import time
+
+from squad_client.core.api import SquadApi
+from yaml import FullLoader, load
+
+from squadutilslib import (
+    ReproducerNotFound,
+    create_custom_reproducer,
+    create_ltp_custom_command,
+    get_file,
+    get_reproducer,
+)
+
+squad_host_url = "https://qa-reports.linaro.org/"
+SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
+
+basicConfig(level=INFO)
+logger = getLogger(__name__)
+
+project_list = [
+    "linux-mainline-master",
+    "linux-next-master",
+    "linux-stable-rc-linux-4.14.y",
+    "linux-stable-rc-linux-4.19.y",
+    "linux-stable-rc-linux-5.4.y",
+    "linux-stable-rc-linux-5.10.y",
+    "linux-stable-rc-linux-5.15.y",
+    "linux-stable-rc-linux-6.1.y",
+    "linux-stable-rc-linux-6.4.y",
+]
+
+
+def get_branch_from_project(project):
+    # regex for mainline/next
+    branch = match("linux-(.+)", project)
+    # regex for rc
+    if not branch:
+        branch = match("linux-stable-rc-(.+)", project)
+    return branch[0]
+
+
+def get_project_from_branch(branch):
+    projects = [project for project in project_list if str(branch) in project]
+    if projects:
+        return projects[0]
+    else:
+        return None
+
+
+def parse_args(raw_args):
+    parser = ArgumentParser(
+        description="Produce TuxRun or TuxPlan reproducers for the LTP skipfile."
+    )
+
+    parser.add_argument(
+        "--group",
+        required=True,
+        help="The name of the SQUAD group.",
+    )
+
+    parser.add_argument(
+        "--allow-unfinished",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Allow fetching of reproducers where the build is marked as unfinished.",
+    )
+
+    parser.add_argument(
+        "--projects",
+        required=False,
+        action="extend",
+        nargs="+",
+        help="A list of SQUAD projects to be tested.",
+    )
+
+    parser.add_argument(
+        "--build-names",
+        required=False,
+        action="extend",
+        nargs="+",
+        help="The list of accepted build names (for example, gcc-12-lkftconfig). Regex is supported.",
+    )
+
+    parser.add_argument(
+        "--debug",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Display debug messages.",
+    )
+
+    parser.add_argument(
+        "--device-names",
+        required=False,
+        action="extend",
+        nargs="+",
+        help="The list of device names (for example, qemu-arm64).",
+    )
+
+    parser.add_argument(
+        "--count",
+        required=False,
+        default=10,
+        type=int,
+        help="The number of builds to fetch when searching for a reproducer.",
+    )
+
+    parser.add_argument(
+        "--skipfile-url",
+        required=False,
+        default="https://raw.githubusercontent.com/Linaro/test-definitions/master/automated/linux/ltp/skipfile-lkft.yaml",
+        help="URL of the skipfile to test.",
+    )
+
+    parser.add_argument(
+        "--suite-name",
+        required=False,
+        default="ltp-syscalls",
+        help="The suite name to grab a reproducer for.",
+    )
+
+    return parser.parse_args(raw_args)
+
+
+def run(raw_args=None):
+    start = time()
+    args = parse_args(raw_args)
+
+    if not args.device_names:
+        args.device_names = ["qemu-armv7", "qemu-arm64", "qemu-i386", "qemu-x86_64"]
+    if not args.projects:
+        args.projects = project_list
+    if not args.build_names:
+        args.build_names = ["gcc-12-lkftconfig", "gcc-\d\d-lkftconfig"]
+
+    skipfile = get_file(args.skipfile_url)
+
+    reason_list = []
+    reproducer_scripts = []
+
+    with open(skipfile) as f:
+        reasons = load(f, Loader=FullLoader)
+    for reason in reasons["skiplist"]:
+        # If 'boards' is set to 'all' or at least one board for the skipfile entry
+        # is in the list of devices we want to test
+        if (
+            reason["boards"] == args.device_names
+            or reason["boards"] == "all"
+            or (set(args.device_names) & set(reason["boards"]))
+            or "all" in reason["boards"]
+        ):
+            if reason["branches"] == "all" or "all" in reason["branches"]:
+                projects = args.projects
+            else:
+                projects = [
+                    get_project_from_branch(branch)
+                    for branch in reason["branches"]
+                    if branch in reason["branches"]
+                ]
+
+            # Create a cleaned version of the skipfile reason that is easier to
+            # work with
+            cleaned_reason = {}
+            if isinstance(reason["tests"], list):
+                cleaned_reason["tests"] = reason["tests"]
+            else:
+                cleaned_reason["tests"] = [reason["tests"]]
+
+            cleaned_reason["projects"] = projects
+
+            reason_list.append(cleaned_reason)
+
+    for project in [get_project_from_branch(project) for project in args.projects]:
+        reproducer_script_name = f"skipfile-reproducer-{args.group}-{project}"
+        if Path(reproducer_script_name).exists():
+            Path.unlink(Path(reproducer_script_name))
+        tmp_custom_reproducer_filename = reproducer_script_name + "_tmp_reproducer"
+        for device in args.device_names:
+            try:
+                fetched_reproducer = get_reproducer(
+                    args.group,
+                    project,
+                    device,
+                    args.debug,
+                    args.build_names,
+                    args.suite_name,
+                    args.count,
+                    tmp_custom_reproducer_filename,
+                    args.allow_unfinished,
+                    local=True,
+                )
+            except ReproducerNotFound:
+                logger.error(
+                    f"No reproducer could be found for {args.group} {project} {device} {args.build_names}"
+                )
+                return -1
+
+            for reason in reason_list:
+                if project in reason["projects"]:
+                    custom_command = create_ltp_custom_command(tests=reason["tests"])
+                    reproducer = create_custom_reproducer(
+                        fetched_reproducer,
+                        args.suite_name,
+                        custom_command,
+                        tmp_custom_reproducer_filename,
+                        local=True,
+                    )
+                    if not Path(reproducer_script_name).exists():
+                        reproducer_scripts.append(reproducer_script_name)
+                    with open(reproducer_script_name, "a+") as multiple_reproducer_file:
+                        for line in reproducer.split("\n"):
+                            # Don't write back the #!/bin/bash part of reproducer
+                            if "#!/bin/bash" != line.strip():
+                                multiple_reproducer_file.write(line + "\n")
+
+                    logger.debug(reproducer)
+
+        if Path(tmp_custom_reproducer_filename).exists():
+            Path.unlink(Path(tmp_custom_reproducer_filename))
+
+    logger.info(
+        "Finished creating skipfile reproducers. Files created: %s",
+        ", ".join(reproducer_scripts),
+    )
+    logger.debug(f"Took {time() - start}s")
+
+
+if __name__ == "__main__":
+    exit(run())

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -36,7 +36,7 @@ def get_file(path, filename=None):
     downloaded file. If an existing file path is passed in, return the path. If
     a non-existent path is passed in, raise an exception.
     """
-    logger.info(f"Getting file from {path}")
+    logger.debug(f"Getting file from {path}")
     if search(r"https?://", path):
         request = get(path, allow_redirects=True)
         request.raise_for_status()
@@ -76,9 +76,9 @@ def find_first_good_testrun(
         # Only pick builds that are finished, unless we specify that unfinished
         # builds are allowed
         if not build.finished and not allow_unfinished:
-            logger.info(f"Skipping {build.id} as build is not marked finished")
+            logger.debug(f"Skipping {build.id} as build is not marked finished")
             continue
-        logger.info(f"Checking build {build.id}")
+        logger.debug(f"Checking build {build.id}")
         # Create the list of suite IDs from the suite names
         if suite_names:
             for s in suite_names:
@@ -167,7 +167,7 @@ def get_reproducer(
 
     # Get the reproducer if a testrun is found
     if testrun:
-        logger.info(
+        logger.debug(
             f"Found testrun {testrun} with build_name {testrun.metadata.build_name}, url: {testrun.url}"
         )
 

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -177,15 +177,17 @@ def get_reproducer(
 
         try:
             if local:
-                tuxrun = get_file(f"{testrun.job_url}/reproducer", filename=filename)
+                reproducer = get_file(
+                    f"{testrun.job_url}/reproducer", filename=filename
+                )
             else:
-                tuxrun = get_file(
+                reproducer = get_file(
                     f"{testrun.job_url}/tuxsuite_reproducer", filename=filename
                 )
         except HTTPError:
             logger.error(f"Reproducer not found at {testrun.job_url}!")
             raise ReproducerNotFound
-        return tuxrun
+        return reproducer
     else:
         raise ReproducerNotFound
 

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -186,21 +186,19 @@ def get_reproducer(
         except HTTPError:
             logger.error(f"Reproducer not found at {testrun.job_url}!")
             raise ReproducerNotFound
-        return reproducer
+        return Path(reproducer).read_text(encoding="utf-8")
     else:
         raise ReproducerNotFound
 
 
-def create_custom_reproducer(
-    reproducer, suite, custom_commands, local=False, filename="reproducer"
-):
+def create_custom_reproducer(reproducer, suite, custom_commands, filename, local=False):
     """
     Given an existing TuxRun or TuxTest reproducer, edit this reproducer to run
     a given custom command.
     """
     build_cmdline = ""
 
-    for line in Path(reproducer).read_text(encoding="utf-8").split("\n"):
+    for line in reproducer.split("\n"):
         if ("tuxsuite test submit" in line and not local) or (
             "tuxrun --runtime" in line and local
         ):
@@ -224,4 +222,4 @@ def create_custom_reproducer(
     reproducer_list = f"""#!/bin/bash\n{build_cmdline}"""
     Path(filename).write_text(reproducer_list, encoding="utf-8")
 
-    return filename
+    return Path(filename).read_text(encoding="utf-8")

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -223,3 +223,7 @@ def create_custom_reproducer(reproducer, suite, custom_commands, filename, local
     Path(filename).write_text(reproducer_list, encoding="utf-8")
 
     return Path(filename).read_text(encoding="utf-8")
+
+
+def create_ltp_custom_command(tests):
+    return f"cd /opt/ltp && ./runltp -s {' '.join(tests)}"


### PR DESCRIPTION
Add support for rerunning the tests in the LTP skipfile via the `squad-create-skipfile-reproducers` script.

By default, if only the `group` parameter is provided, the script will create a TuxPlan of reproducers for all supported QEMU devices and branches.

Builds on https://github.com/Linaro/squad-client-utils/pull/21