### PR TITLE
[RFC] auto recent branch detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,45 @@ options:
                         The number of builds to fetch when searching for a reproducer.
 ```
 
+### `squad-create-skipfile-reproducers`: Creating skipfile reproducers
+
+The `squad-create-skipfile-reproducers` script can be used to create TuxRun or
+TuxPlan reproducers for the LTP skipfile.
+
+```
+./squad-create-skipfile-reproducers --help
+usage: squad-create-skipfile-reproducers [-h] --group GROUP [--allow-unfinished]
+                                         [--branches BRANCHES [BRANCHES ...]]
+                                         [--build-names BUILD_NAMES [BUILD_NAMES ...]]
+                                         [--debug]
+                                         [--device-names DEVICE_NAMES [DEVICE_NAMES ...]]
+                                         [--local] [--search-build-count SEARCH_BUILD_COUNT]
+                                         [--skipfile-url SKIPFILE_URL]
+                                         [--suite-name SUITE_NAME]
+
+Produce TuxRun or TuxPlan reproducers for the LTP skipfile.
+
+options:
+  -h, --help            show this help message and exit
+  --group GROUP         The name of the SQUAD group.
+  --allow-unfinished    Allow fetching of reproducers where the build is marked as unfinished.
+  --branches BRANCHES [BRANCHES ...]
+                        A list of SQUAD branches to be tested.
+  --build-names BUILD_NAMES [BUILD_NAMES ...]
+                        The list of accepted build names (for example, gcc-12-lkftconfig).
+                        Regex is supported.
+  --debug               Display debug messages.
+  --device-names DEVICE_NAMES [DEVICE_NAMES ...]
+                        The list of device names (for example, qemu-arm64).
+  --local               Create a TuxRun reproducer when updating rather than a TuxPlan.
+  --search-build-count SEARCH_BUILD_COUNT
+                        The number of builds to fetch when searching for a reproducer.
+  --skipfile-url SKIPFILE_URL
+                        URL of the skipfile to test.
+  --suite-name SUITE_NAME
+                        The suite name to grab a reproducer for.
+```
+
 ## Contributing
 
 This (alpha) project is managed on [`github`](https://github.com) at https://github.com/Linaro/squad-client-utils

--- a/generate-skipfile-plan-names
+++ b/generate-skipfile-plan-names
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+
+import sys
+
+linux_stable_rc_branches = {
+    "linux-4.14.y": "linux-stable-rc",
+    "linux-4.19.y": "linux-stable-rc",
+    "linux-5.4.y": "linux-stable-rc",
+    "linux-5.10.y": "linux-stable-rc",
+    "linux-5.15.y": "linux-stable-rc",
+    "linux-6.1.y": "linux-stable-rc",
+    "linux-6.2.y": "linux-stable-rc",
+}
+
+linux_mainline_next_branches = {
+    "linux-mainline": "master",
+    "linux-next": "master",
+}
+
+
+def look_up_project_by_branch(branch_name):
+    if branch_name in linux_stable_rc_branches:
+        return f"{linux_stable_rc_branches[branch_name]}-{branch_name}"
+    elif branch_name in linux_mainline_next_branches:
+        return f"{branch_name}-{linux_mainline_next_branches[branch_name]}"
+    else:
+        raise Exception(
+            "Unknown branch name {0}. \nSupported branch names: \n\t- {1}".format(
+                branch_name, "\n\t- ".join(supported_branch_names())
+            )
+        )
+
+
+def supported_branch_names():
+    return list(linux_stable_rc_branches) + list(linux_mainline_next_branches)
+
+
+if __name__ == "__main__":
+    for project in [look_up_project_by_branch(branch) for branch in supported_branch_names()]:
+        print(f"skipfile-reproducer-{project}-plan.yaml")
+    sys.exit(0)

--- a/generate-skipfile-plan-names
+++ b/generate-skipfile-plan-names
@@ -43,6 +43,8 @@ def supported_branch_names():
 
 
 if __name__ == "__main__":
-    for project in [look_up_project_by_branch(branch) for branch in supported_branch_names()]:
-        print(f"skipfile-reproducer-{project}-plan.yaml")
+    for project in [
+        look_up_project_by_branch(branch) for branch in supported_branch_names()
+    ]:
+        print(f"skipfile-reproducer-lkft-{project}-plan.yaml")
     sys.exit(0)

--- a/read-skipfile-results
+++ b/read-skipfile-results
@@ -1,0 +1,201 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+from git import Repo
+from ruamel.yaml import YAML
+from squad_client.core.api import SquadApi
+from squad_client.core.models import Environment, Squad, TestRun
+from squad_client.utils import first, getid
+
+from squadutilslib import get_file
+
+
+def parse_args(raw_args):
+    parser = argparse.ArgumentParser(description="Read results and update skipfile")
+
+    parser.add_argument(
+        "--group-name",
+        required=True,
+    )
+    parser.add_argument(
+        "--squad-host",
+        required=False,
+        default="https://qa-reports.linaro.org/",
+    )
+    parser.add_argument(
+        "--project_name",
+        required=False,
+        default="skipfile-testing",
+    )
+
+    parser.add_argument(
+        "--skipfile",
+        required=False,
+        default="test-definitions/automated/linux/ltp/skipfile-lkft.yaml",
+    )
+
+    return parser.parse_args(raw_args)
+
+
+def delete_skiplist_entry(skipfile, url):
+    """
+    Delete an entry from the skiplist (for example, when a bug has been fixed)
+    """
+    skipfile["skiplist"] = [test for test in skipfile["skiplist"] if url != test["url"]]
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run(raw_args=None):
+    args = parse_args(raw_args)
+    SquadApi.configure(cache=3600, url=os.getenv("SQUAD_HOST", args.squad_host))
+
+    builds = "builds_for_skipfile_runs.txt"
+    group = Squad().group(args.group_name)
+    project = group.project(args.project_name)
+
+    builds_list_file = open(builds, "r")
+    squad_builds = builds_list_file.readlines()
+
+    results_file_name = "results.csv"
+    results_file = open(results_file_name, "w+")
+
+    skipfile_name = args.skipfile
+
+    # clone into test-definitions
+    git_url = "git@github.com:Linaro/test-definitions.git"
+    repo_path = "test-definitions"
+    if pathlib.Path(repo_path).is_dir():
+        shutil.rmtree(pathlib.Path(repo_path))
+
+    repo = Repo.clone_from(git_url, repo_path)
+    # TODO Any hangs will not produce a result - so the results file will contain the results for only non-hanging tests.
+    test_rerun_count = 1
+
+    # Read skipfile
+    skipfile_txt = pathlib.Path(skipfile_name).read_text()
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    skipfile = yaml.load(skipfile_txt)
+    # fix formatting and create a commit for it
+    with open(skipfile_name, "w") as output_yaml:
+        yaml.dump(skipfile, output_yaml)
+
+    repo.git.add(u=True)
+    repo.git.commit(
+        "-m",
+        "Updates to formatting\n\nUpdates to formatting for skipfile automated updates",
+    )
+    os.chdir(repo_path)
+    var = subprocess.check_output(["git", "format-patch", "--stdout", "HEAD~1"]).decode(
+        "utf-8"
+    )
+    os.chdir("..")
+    print(f"out:\n{var}")
+
+    for build_name in squad_builds:
+        logger.info(f"SQUAD build name {build_name}")
+        # Get the build metadata
+
+        # TODO - change this to remove the current architecture until there and none left.
+        # TODO - support multiple runs and collate results
+        if build_name != "":
+            build = first(project.builds(version=build_name))
+            tests = build.tests()
+            for test in tests.values():
+                print(test)
+                # We only care about the custom commands not boot
+                if "commands" in test.name:
+                    env = Environment(getid(test.environment))
+                    testrun = TestRun(getid(test.test_run))
+                    get_file(testrun.job_url + "/results")
+                    reproducer = open("results", "r")
+                    # reproducer = open("failing_test.json", "r")
+                    results_json = json.load(reproducer)
+                    try:
+                        # gets the name of the custom command
+                        name = (
+                            results_json["lava"]["commands"]["repository"]["run"][
+                                "steps"
+                            ][0]
+                            .split(" ")[1]
+                            .strip()
+                        )
+                        # Gets the result if the test did not time out
+                        overall_result = results_json["commands"][name]["result"]
+                        # tests
+                        tests = (
+                            results_json["lava"]["commands"]["repository"]["run"][
+                                "steps"
+                            ][0]
+                            .split("cd /opt/ltp && ./runltp -s ")[1]
+                            .strip()
+                        )
+                        print(tests)
+                        tests = re.sub("'", "", tests)
+                        tests = re.sub('"', "", tests).split(" ")
+                        print(tests)
+
+                        # Create pastebin link
+
+                        skipfile["skiplist"] = [
+                            skipitem
+                            for skipitem in skipfile["skiplist"]
+                            if (set(tests).difference(set(skipitem["tests"])))
+                        ]
+
+                        # Produce skipfile update
+                        with open(skipfile_name, "w") as output_yaml:
+                            yaml.dump(skipfile, output_yaml)
+
+                        # make updates and create a commit for it
+                        with open(skipfile_name, "w") as output_yaml:
+                            yaml.dump(skipfile, output_yaml)
+
+                        repo.git.add(u=True)
+                        tests_string = ", ".join(tests)
+                        repo.git.commit(
+                            "-m",
+                            f"Updates to skipfile to remove {tests_string}",
+                        )
+                        os.chdir(repo_path)
+                        var = subprocess.check_output(
+                            ["git", "format-patch", "--stdout", "HEAD~1"]
+                        ).decode("utf-8")
+                        os.chdir("..")
+                        print(f"out:\n{var}")
+
+                    except KeyError:
+                        overall_result = "result not found - investigate"
+
+                    # Get runtime
+                    try:
+                        time = results_json["lava"]["commands"]["duration"]
+                    except KeyError:
+                        time = "time not found"
+                    results_file.write(
+                        f"{test.short_name},{testrun.job_url},{env.slug},{time},{overall_result}\n"
+                    )
+
+                    print(f"Results saved to {results_file_name}")
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/read-skipfile-results
+++ b/read-skipfile-results
@@ -7,10 +7,12 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+import copy
 import json
 import logging
 import os
 import pathlib
+import pprint
 import re
 import shutil
 import subprocess
@@ -23,6 +25,20 @@ from squad_client.core.models import Environment, Squad, TestRun
 from squad_client.utils import first, getid
 
 from squadutilslib import get_file
+
+# TODO - change this to a generated list
+all_boards = [
+    "qemu-arm64",
+    "qemu_arm64",
+    "qemu-armv7",
+    "qemu_arm",
+    "qemu-x86",
+    "qemu_x86",
+    "qemu-i386",
+    "qemu_i386",
+    "i386",
+    "juno-r2",
+]
 
 
 def parse_args(raw_args):
@@ -78,16 +94,17 @@ def run(raw_args=None):
     results_file = open(results_file_name, "w+")
 
     skipfile_name = args.skipfile
+    commit_dir = "skipfile_update_commits"
+    os.mkdir(commit_dir)
 
     # clone into test-definitions
-    git_url = "git@github.com:Linaro/test-definitions.git"
     repo_path = "test-definitions"
-    if pathlib.Path(repo_path).is_dir():
-        shutil.rmtree(pathlib.Path(repo_path))
+    repo = Repo(repo_path)
 
-    repo = Repo.clone_from(git_url, repo_path)
     # TODO Any hangs will not produce a result - so the results file will contain the results for only non-hanging tests.
     test_rerun_count = 1
+    pass_counts = dict()
+    patch_count = 0
 
     # Read skipfile
     skipfile_txt = pathlib.Path(skipfile_name).read_text()
@@ -99,20 +116,28 @@ def run(raw_args=None):
         yaml.dump(skipfile, output_yaml)
 
     repo.git.add(u=True)
-    repo.git.commit(
-        "-m",
-        "Updates to formatting\n\nUpdates to formatting for skipfile automated updates",
-    )
-    os.chdir(repo_path)
-    var = subprocess.check_output(["git", "format-patch", "--stdout", "HEAD~1"]).decode(
-        "utf-8"
-    )
-    os.chdir("..")
-    print(f"out:\n{var}")
+    if repo.index.diff("HEAD"):
+        repo.git.commit(
+            "-m",
+            "Updates to formatting\n\nUpdates to formatting for skipfile automated updates.",
+        )
+        os.chdir(repo_path)
+        var = subprocess.check_output(
+            ["git", "format-patch", "--stdout", "HEAD~1"]
+        ).decode("utf-8")
+        os.chdir("..")
+        print(f"\n{var}")
+        with open(
+            f"{commit_dir}/update_0000_reformat_skipfile.diff",
+            "w",
+        ) as f:
+            f.write(f"{var}")
+            patch_count += 1
 
+    # Loop through and count the non hangs
     for build_name in squad_builds:
         logger.info(f"SQUAD build name {build_name}")
-        # Get the build metadata
+        # TODO Get the build metadata
 
         # TODO - change this to remove the current architecture until there and none left.
         # TODO - support multiple runs and collate results
@@ -120,7 +145,6 @@ def run(raw_args=None):
             build = first(project.builds(version=build_name))
             tests = build.tests()
             for test in tests.values():
-                print(test)
                 # We only care about the custom commands not boot
                 if "commands" in test.name:
                     env = Environment(getid(test.environment))
@@ -148,39 +172,28 @@ def run(raw_args=None):
                             .split("cd /opt/ltp && ./runltp -s ")[1]
                             .strip()
                         )
-                        print(tests)
                         tests = re.sub("'", "", tests)
                         tests = re.sub('"', "", tests).split(" ")
-                        print(tests)
 
-                        # Create pastebin link
-
-                        skipfile["skiplist"] = [
-                            skipitem
-                            for skipitem in skipfile["skiplist"]
-                            if (set(tests).difference(set(skipitem["tests"])))
-                        ]
-
-                        # Produce skipfile update
-                        with open(skipfile_name, "w") as output_yaml:
-                            yaml.dump(skipfile, output_yaml)
-
-                        # make updates and create a commit for it
-                        with open(skipfile_name, "w") as output_yaml:
-                            yaml.dump(skipfile, output_yaml)
-
-                        repo.git.add(u=True)
-                        tests_string = ", ".join(tests)
-                        repo.git.commit(
-                            "-m",
-                            f"Updates to skipfile to remove {tests_string}",
+                        # get device type from reproducer
+                        get_file(testrun.job_url + "/reproducer")
+                        reproducer = pathlib.Path("reproducer").read_text(
+                            encoding="utf-8"
                         )
-                        os.chdir(repo_path)
-                        var = subprocess.check_output(
-                            ["git", "format-patch", "--stdout", "HEAD~1"]
-                        ).decode("utf-8")
-                        os.chdir("..")
-                        print(f"out:\n{var}")
+                        device = re.findall("--device (\S+)", reproducer)[0]
+                        tests_string = ",".join(sorted(tests))
+                        if tests_string in pass_counts:
+                            if device in pass_counts[tests_string]["count"]:
+                                pass_counts[tests_string]["count"][device] += 1
+                            else:
+                                pass_counts[tests_string][device] = dict()
+                                pass_counts[tests_string]["count"][device] = 1
+                                pass_counts[tests_string]["test_list"] = tests
+                        else:
+                            pass_counts[tests_string] = dict()
+                            pass_counts[tests_string]["count"] = dict()
+                            pass_counts[tests_string]["count"][device] = 1
+                            pass_counts[tests_string]["test_list"] = tests
 
                     except KeyError:
                         overall_result = "result not found - investigate"
@@ -195,6 +208,72 @@ def run(raw_args=None):
                     )
 
                     print(f"Results saved to {results_file_name}")
+    # Once counted, loop through results and create commits
+    tests = ""
+    update = False
+    for test_name in pass_counts:
+        # TODO add branches
+        for device in pass_counts[test_name]["count"]:
+            if pass_counts[test_name]["count"][device] == test_rerun_count:
+                new_skiplist = []
+                for skipitem in skipfile["skiplist"]:
+                    # search for test to remove
+                    tests = pass_counts[test_name]["test_list"]
+                    if set(tests).difference(set(skipitem["tests"])):
+                        new_skiplist.append(skipitem)
+                    else:
+                        # remove device
+
+                        new_skipitem = copy.deepcopy(skipitem)
+                        if new_skipitem["boards"] == "all":
+                            new_skipitem["boards"] = ["all"]
+
+                        if isinstance(new_skipitem["boards"], list):
+                            if "all" in new_skipitem["boards"]:
+                                new_skipitem["boards"] = copy.deepcopy(all_boards)
+                                if device in new_skipitem["boards"]:
+                                    new_skipitem["boards"].remove(device)
+                                    update = True
+                            else:
+                                if device in new_skipitem["boards"]:
+                                    new_skipitem["boards"].remove(device)
+                                    update = True
+                            new_skiplist.append(new_skipitem)
+
+                if update:
+                    skipfile["skiplist"] = new_skiplist
+
+                    # if there are changes, update skipfile
+                    # Produce skipfile update
+                    with open(skipfile_name, "w") as output_yaml:
+                        yaml.dump(skipfile, output_yaml)
+
+                    # make updates and create a commit for it
+                    with open(skipfile_name, "w") as output_yaml:
+                        yaml.dump(skipfile, output_yaml)
+
+                    repo.git.add(u=True)
+                    tests_string = ", ".join(tests)
+                    repo.git.commit(
+                        "-m",
+                        f"Updates to skipfile to remove {tests_string}",
+                    )
+                    os.chdir(repo_path)
+                    var = subprocess.check_output(
+                        ["git", "format-patch", "--stdout", "HEAD~1"]
+                    ).decode("utf-8")
+                    os.chdir("..")
+                    print(f"\n{var}")
+                    with open(
+                        f"{commit_dir}/update_{patch_count:04}_{test_name}_{device}.diff",
+                        "w",
+                    ) as f:
+                        f.write(f"{var}")
+                    patch_count += 1
+                    update = False
+
+    # TODO Create pastebin link
+    return 0
 
 
 if __name__ == "__main__":

--- a/run-and-push-skipfile-results
+++ b/run-and-push-skipfile-results
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+GROUP_NAME=$1
+PROJECT_NAME=$2
+
+if [ "$#" -ne 2 ]
+then
+    echo "usage: ./run-and-push-skipfile-results <group_name> <project_name>"
+else
+    rm builds_for_skipfile_runs.txt
+    for PLAN in $(./generate-skipfile-plan-names)
+    do
+        tuxsuite plan $PLAN --json-out $PLAN.json --no-wait
+        BUILD="$PLAN-$(date +'%s')"
+        squad-client submit-tuxsuite --group=$GROUP_NAME --project=$PROJECT_NAME --build=$BUILD --backend tuxsuite.com --json $PLAN.json
+        echo $BUILD >> builds_for_skipfile_runs.txt
+    done
+fi

--- a/run-and-push-skipfile-results
+++ b/run-and-push-skipfile-results
@@ -6,9 +6,14 @@ PROJECT_NAME=$2
 if [ "$#" -ne 2 ]; then
     echo "usage: ./run-and-push-skipfile-results <group_name> <project_name>"
 else
-    rm builds_for_skipfile_runs.txt
-    for PLAN in $(./generate-skipfile-plan-names); do
+
+    run_list=builds_for_skipfile_runs.txt
+    if test -f "$run_list"; then
+        rm "$run_list"
+    fi
+    for PLAN in $(python generate-skipfile-plan-names); do
         if test -f "$PLAN"; then
+            echo "$PLAN"
             tuxsuite plan $PLAN --json-out $PLAN.json --no-wait
             BUILD="$PLAN-$(date +'%s')"
             squad-client submit-tuxsuite --group=$GROUP_NAME --project=$PROJECT_NAME --build=$BUILD --backend tuxsuite.com --json $PLAN.json

--- a/run-and-push-skipfile-results
+++ b/run-and-push-skipfile-results
@@ -3,16 +3,16 @@
 GROUP_NAME=$1
 PROJECT_NAME=$2
 
-if [ "$#" -ne 2 ]
-then
+if [ "$#" -ne 2 ]; then
     echo "usage: ./run-and-push-skipfile-results <group_name> <project_name>"
 else
     rm builds_for_skipfile_runs.txt
-    for PLAN in $(./generate-skipfile-plan-names)
-    do
-        tuxsuite plan $PLAN --json-out $PLAN.json --no-wait
-        BUILD="$PLAN-$(date +'%s')"
-        squad-client submit-tuxsuite --group=$GROUP_NAME --project=$PROJECT_NAME --build=$BUILD --backend tuxsuite.com --json $PLAN.json
-        echo $BUILD >> builds_for_skipfile_runs.txt
+    for PLAN in $(./generate-skipfile-plan-names); do
+        if test -f "$PLAN"; then
+            tuxsuite plan $PLAN --json-out $PLAN.json --no-wait
+            BUILD="$PLAN-$(date +'%s')"
+            squad-client submit-tuxsuite --group=$GROUP_NAME --project=$PROJECT_NAME --build=$BUILD --backend tuxsuite.com --json $PLAN.json
+            echo $BUILD >>builds_for_skipfile_runs.txt
+        fi
     done
 fi

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -7,26 +7,26 @@
 # SPDX-License-Identifier: MIT
 
 
-import argparse
-import logging
-import os
-import pathlib
-import sys
+from argparse import ArgumentParser
+from logging import INFO, basicConfig, getLogger
+from os import chmod, getenv
+from pathlib import Path
 from stat import S_IRUSR, S_IWUSR, S_IXUSR
+from sys import exit
 
 from squad_client.core.api import SquadApi
 
-import squadutilslib
+from squadutilslib import ReproducerNotFound, create_custom_reproducer, get_reproducer
 
 squad_host_url = "https://qa-reports.linaro.org/"
-SquadApi.configure(cache=3600, url=os.getenv("SQUAD_HOST", squad_host_url))
+SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+basicConfig(level=INFO)
+logger = getLogger(__name__)
 
 
 def parse_args(raw_args):
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description="Get the latest TuxRun reproducer for a given group, project, device and suite."
         + " The reproducer will be printed to the terminal and written to a file."
         + " Optionally update the TuxRun reproducer to run custom commands and/or run in the cloud with TuxTest."
@@ -116,7 +116,7 @@ def run(raw_args=None):
     args = parse_args(raw_args)
 
     try:
-        reproducer_file = squadutilslib.get_reproducer(
+        reproducer_file = get_reproducer(
             args.group,
             args.project,
             args.device_name,
@@ -128,7 +128,7 @@ def run(raw_args=None):
             args.allow_unfinished,
             args.local,
         )
-    except squadutilslib.ReproducerNotFound as e:
+    except ReproducerNotFound as e:
         logger.error(
             f"No reproducer could be found for {args.group} {args.project} {args.device_name} {args.build_names}"
         )
@@ -136,7 +136,7 @@ def run(raw_args=None):
         return -1
 
     if args.custom_command:
-        reproducer_file = squadutilslib.create_custom_reproducer(
+        reproducer_file = create_custom_reproducer(
             reproducer_file,
             args.suite_name,
             args.custom_command,
@@ -144,14 +144,14 @@ def run(raw_args=None):
             args.filename,
         )
 
-    reproducer = pathlib.Path(reproducer_file).read_text(encoding="utf-8")
+    reproducer = Path(reproducer_file).read_text(encoding="utf-8")
 
     print(reproducer)
 
     # Make the script executable
-    os.chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
+    chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
     logger.info(f"file created: {reproducer_file}")
 
 
 if __name__ == "__main__":
-    sys.exit(run())
+    exit(run())

--- a/squad-create-reproducer
+++ b/squad-create-reproducer
@@ -116,7 +116,7 @@ def run(raw_args=None):
     args = parse_args(raw_args)
 
     try:
-        reproducer_file = get_reproducer(
+        reproducer = get_reproducer(
             args.group,
             args.project,
             args.device_name,
@@ -136,21 +136,19 @@ def run(raw_args=None):
         return -1
 
     if args.custom_command:
-        reproducer_file = create_custom_reproducer(
-            reproducer_file,
+        reproducer = create_custom_reproducer(
+            reproducer,
             args.suite_name,
             args.custom_command,
-            args.local,
             args.filename,
+            args.local,
         )
-
-    reproducer = Path(reproducer_file).read_text(encoding="utf-8")
 
     print(reproducer)
 
     # Make the script executable
-    chmod(reproducer_file, S_IXUSR | S_IRUSR | S_IWUSR)
-    logger.info(f"file created: {reproducer_file}")
+    chmod(args.filename, S_IXUSR | S_IRUSR | S_IWUSR)
+    logger.info(f"file created: {args.filename}")
 
 
 if __name__ == "__main__":

--- a/squad-create-skipfile-reproducers
+++ b/squad-create-skipfile-reproducers
@@ -1,0 +1,243 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+from argparse import ArgumentParser
+from logging import INFO, basicConfig, getLogger
+from os import getenv
+from pathlib import Path
+from sys import exit
+from time import time
+
+from squad_client.core.api import SquadApi
+from yaml import FullLoader, load
+
+from squadutilslib import (
+    ReproducerNotFound,
+    create_custom_reproducer,
+    create_ltp_custom_command,
+    get_file,
+    get_reproducer,
+)
+
+squad_host_url = "https://qa-reports.linaro.org/"
+SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
+
+basicConfig(level=INFO)
+logger = getLogger(__name__)
+
+linux_stable_rc_branches = {
+    "linux-4.14.y": "linux-stable-rc",
+    "linux-4.19.y": "linux-stable-rc",
+    "linux-5.4.y": "linux-stable-rc",
+    "linux-5.10.y": "linux-stable-rc",
+    "linux-5.15.y": "linux-stable-rc",
+    "linux-6.1.y": "linux-stable-rc",
+    "linux-6.3.y": "linux-stable-rc",
+}
+
+linux_mainline_next_branches = {
+    "linux-mainline": "master",
+    "linux-next": "master",
+}
+
+
+def supported_branch_names():
+    return list(linux_stable_rc_branches) + list(linux_mainline_next_branches)
+
+
+def look_up_project_by_branch(branch_name):
+    if branch_name in linux_stable_rc_branches:
+        return f"{linux_stable_rc_branches[branch_name]}-{branch_name}"
+    elif branch_name in linux_mainline_next_branches:
+        return f"{branch_name}-{linux_mainline_next_branches[branch_name]}"
+    else:
+        raise Exception(
+            "Unknown branch name {0}. \nSupported branch names: \n\t- {1}".format(
+                branch_name, "\n\t- ".join(supported_branch_names())
+            )
+        )
+
+
+def parse_args(raw_args):
+    parser = ArgumentParser(
+        description="Produce TuxRun or TuxPlan reproducers for the LTP skipfile."
+    )
+
+    parser.add_argument(
+        "--group",
+        required=True,
+        help="The name of the SQUAD group.",
+    )
+
+    parser.add_argument(
+        "--allow-unfinished",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Allow fetching of reproducers where the build is marked as unfinished.",
+    )
+
+    parser.add_argument(
+        "--branches",
+        required=False,
+        default=supported_branch_names(),
+        nargs="+",
+        help="A list of SQUAD branches to be tested.",
+    )
+
+    parser.add_argument(
+        "--build-names",
+        required=False,
+        default=["gcc-12-lkftconfig", "gcc-\d\d-lkftconfig"],
+        nargs="+",
+        help="The list of accepted build names (for example, gcc-12-lkftconfig). Regex is supported.",
+    )
+
+    parser.add_argument(
+        "--debug",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Display debug messages.",
+    )
+
+    parser.add_argument(
+        "--device-names",
+        required=False,
+        default=["qemu-armv7", "qemu-arm64", "qemu-i386", "qemu-x86_64"],
+        nargs="+",
+        help="The list of device names (for example, qemu-arm64).",
+    )
+
+    parser.add_argument(
+        "--search-build-count",
+        required=False,
+        default=10,
+        type=int,
+        help="The number of builds to fetch when searching for a reproducer.",
+    )
+
+    parser.add_argument(
+        "--skipfile-url",
+        required=False,
+        default="https://raw.githubusercontent.com/Linaro/test-definitions/master/automated/linux/ltp/skipfile-lkft.yaml",
+        help="URL of the skipfile to test.",
+    )
+
+    parser.add_argument(
+        "--suite-name",
+        required=False,
+        default="ltp-syscalls",
+        help="The suite name to grab a reproducer for.",
+    )
+
+    return parser.parse_args(raw_args)
+
+
+def run(raw_args=None):
+    start = time()
+    args = parse_args(raw_args)
+
+    skipfile = get_file(args.skipfile_url)
+
+    reason_list = []
+    reproducer_scripts = []
+
+    with open(skipfile) as f:
+        reasons = load(f, Loader=FullLoader)
+    for reason in reasons["skiplist"]:
+        # If 'boards' is set to 'all' or at least one board for the skipfile entry
+        # is in the list of devices we want to test
+        if (
+            reason["boards"] == args.device_names
+            or reason["boards"] == "all"
+            or (set(args.device_names) & set(reason["boards"]))
+            or "all" in reason["boards"]
+        ):
+            if reason["branches"] == "all" or "all" in reason["branches"]:
+                projects = [
+                    look_up_project_by_branch(branch) for branch in args.branches
+                ]
+            else:
+                for branch_name in reason["branches"]:
+                    if branch_name in args.branches:
+                        projects.append(look_up_project_by_branch(branch_name))
+                    else:
+                        logger.debug(
+                            f"Branch name {branch_name} is not supported by this script or was not provided as an argument in --branches. Skipping."
+                        )
+
+            # Create a cleaned version of the skipfile reason that is easier to
+            # work with
+            cleaned_reason = {}
+            if isinstance(reason["tests"], list):
+                cleaned_reason["tests"] = reason["tests"]
+            else:
+                cleaned_reason["tests"] = [reason["tests"]]
+
+            cleaned_reason["projects"] = projects
+
+            reason_list.append(cleaned_reason)
+
+    for project in [look_up_project_by_branch(project) for project in args.branches]:
+        reproducer_script_name = f"skipfile-reproducer-{args.group}-{project}"
+        if Path(reproducer_script_name).exists():
+            Path.unlink(Path(reproducer_script_name))
+        tmp_custom_reproducer_filename = reproducer_script_name + "_tmp_reproducer"
+        for device in args.device_names:
+            try:
+                fetched_reproducer = get_reproducer(
+                    args.group,
+                    project,
+                    device,
+                    args.debug,
+                    args.build_names,
+                    args.suite_name,
+                    args.search_build_count,
+                    tmp_custom_reproducer_filename,
+                    args.allow_unfinished,
+                    local=True,
+                )
+            except ReproducerNotFound:
+                logger.error(
+                    f"No reproducer could be found for {args.group} {project} {device} {args.build_names}"
+                )
+                return -1
+
+            for reason in reason_list:
+                if project in reason["projects"]:
+                    custom_command = create_ltp_custom_command(tests=reason["tests"])
+                    reproducer = create_custom_reproducer(
+                        fetched_reproducer,
+                        args.suite_name,
+                        custom_command,
+                        tmp_custom_reproducer_filename,
+                        local=True,
+                    )
+                    if not Path(reproducer_script_name).exists():
+                        reproducer_scripts.append(reproducer_script_name)
+                    with open(reproducer_script_name, "a+") as multiple_reproducer_file:
+                        for line in reproducer.split("\n"):
+                            # Don't write back the #!/bin/bash part of reproducer
+                            if "#!/bin/bash" != line.strip():
+                                multiple_reproducer_file.write(line + "\n")
+
+                    logger.debug(reproducer)
+
+        if Path(tmp_custom_reproducer_filename).exists():
+            Path.unlink(Path(tmp_custom_reproducer_filename))
+
+    logger.info(
+        "Finished creating skipfile reproducers. Files created: %s",
+        ", ".join(reproducer_scripts),
+    )
+    logger.debug(f"Took {time() - start}s")
+
+
+if __name__ == "__main__":
+    exit(run())

--- a/squad-create-skipfile-reproducers
+++ b/squad-create-skipfile-reproducers
@@ -20,6 +20,7 @@ from squadutilslib import (
     ReproducerNotFound,
     create_custom_reproducer,
     create_ltp_custom_command,
+    create_tuxsuite_plan_from_tuxsuite_tests,
     get_file,
     get_reproducer,
 )
@@ -113,6 +114,13 @@ def parse_args(raw_args):
         nargs="+",
         help="The list of device names (for example, qemu-arm64).",
     )
+    parser.add_argument(
+        "--local",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Create a TuxRun reproducer when updating rather than a TuxPlan.",
+    )
 
     parser.add_argument(
         "--search-build-count",
@@ -201,7 +209,7 @@ def run(raw_args=None):
                     args.search_build_count,
                     tmp_custom_reproducer_filename,
                     args.allow_unfinished,
-                    local=True,
+                    local=args.local,
                 )
             except ReproducerNotFound:
                 logger.error(
@@ -217,7 +225,7 @@ def run(raw_args=None):
                         args.suite_name,
                         custom_command,
                         tmp_custom_reproducer_filename,
-                        local=True,
+                        local=args.local,
                     )
                     if not Path(reproducer_script_name).exists():
                         reproducer_scripts.append(reproducer_script_name)
@@ -231,6 +239,19 @@ def run(raw_args=None):
 
         if Path(tmp_custom_reproducer_filename).exists():
             Path.unlink(Path(tmp_custom_reproducer_filename))
+
+    if not args.local:
+        reproducer_scripts_tuxplan = []
+        # Convert tuxtest reproducers to tuxplans
+        for reproducer_script_name in reproducer_scripts:
+            plan_name = f"{reproducer_script_name}-plan.yaml"
+            reproducer = create_tuxsuite_plan_from_tuxsuite_tests(
+                reproducer_script_name,
+                plan_name=plan_name,
+            )
+            reproducer_scripts_tuxplan.append(plan_name)
+        Path.unlink(Path(reproducer_script_name))
+        reproducer_scripts = reproducer_scripts_tuxplan
 
     logger.info(
         "Finished creating skipfile reproducers. Files created: %s",

--- a/squad-create-skipfile-reproducers
+++ b/squad-create-skipfile-reproducers
@@ -22,6 +22,7 @@ from squadutilslib import (
     create_ltp_custom_command,
     create_tuxsuite_plan_from_tuxsuite_tests,
     get_file,
+    get_recent_branches,
     get_reproducer,
 )
 
@@ -31,37 +32,37 @@ SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
 basicConfig(level=INFO)
 logger = getLogger(__name__)
 
-linux_stable_rc_branches = {
-    "linux-4.14.y": "linux-stable-rc",
-    "linux-4.19.y": "linux-stable-rc",
-    "linux-5.4.y": "linux-stable-rc",
-    "linux-5.10.y": "linux-stable-rc",
-    "linux-5.15.y": "linux-stable-rc",
-    "linux-6.1.y": "linux-stable-rc",
-    "linux-6.3.y": "linux-stable-rc",
-}
+# linux_stable_rc_branches = {
+#     "linux-4.14.y": "linux-stable-rc",
+#     "linux-4.19.y": "linux-stable-rc",
+#     "linux-5.4.y": "linux-stable-rc",
+#     "linux-5.10.y": "linux-stable-rc",
+#     "linux-5.15.y": "linux-stable-rc",
+#     "linux-6.1.y": "linux-stable-rc",
+#     "linux-6.3.y": "linux-stable-rc",
+# }
 
-linux_mainline_next_branches = {
-    "linux-mainline": "master",
-    "linux-next": "master",
-}
-
-
-def supported_branch_names():
-    return list(linux_stable_rc_branches) + list(linux_mainline_next_branches)
+# linux_mainline_next_branches = {
+#     "linux-mainline": "master",
+#     "linux-next": "master",
+# }
 
 
-def look_up_project_by_branch(branch_name):
-    if branch_name in linux_stable_rc_branches:
-        return f"{linux_stable_rc_branches[branch_name]}-{branch_name}"
-    elif branch_name in linux_mainline_next_branches:
-        return f"{branch_name}-{linux_mainline_next_branches[branch_name]}"
-    else:
-        raise Exception(
-            "Unknown branch name {0}. \nSupported branch names: \n\t- {1}".format(
-                branch_name, "\n\t- ".join(supported_branch_names())
-            )
-        )
+# def supported_branch_names():
+#     return list(linux_stable_rc_branches) + list(linux_mainline_next_branches)
+
+
+# def look_up_project_by_branch(branch_name):
+#     if branch_name in linux_stable_rc_branches:
+#         return f"{linux_stable_rc_branches[branch_name]}-{branch_name}"
+#     elif branch_name in linux_mainline_next_branches:
+#         return f"{branch_name}-{linux_mainline_next_branches[branch_name]}"
+#     else:
+#         raise Exception(
+#             "Unknown branch name {0}. \nSupported branch names: \n\t- {1}".format(
+#                 branch_name, "\n\t- ".join(supported_branch_names())
+#             )
+#         )
 
 
 def parse_args(raw_args):
@@ -86,7 +87,6 @@ def parse_args(raw_args):
     parser.add_argument(
         "--branches",
         required=False,
-        default=supported_branch_names(),
         nargs="+",
         help="A list of SQUAD branches to be tested.",
     )
@@ -144,12 +144,40 @@ def parse_args(raw_args):
         help="The suite name to grab a reproducer for.",
     )
 
+    parser.add_argument(
+        "--days",
+        required=False,
+        default=7,
+        type=int,
+        help="The number of days to look back.",
+    )
+
+    parser.add_argument(
+        "--must-not-contain",
+        required=False,
+        default=["sanity", "tools"],
+        help="Ignore project names that contain any of these terms.",
+    )
+
+    parser.add_argument(
+        "--must-contain",
+        required=False,
+        default=["master", "next", "linux-stable"],
+        help="Project names must contain one of these terms.",
+    )
     return parser.parse_args(raw_args)
 
 
 def run(raw_args=None):
     start = time()
     args = parse_args(raw_args)
+
+    project_lookup = get_recent_branches(
+        args.group, args.days, args.must_contain, args.must_not_contain, args.debug
+    )
+
+    if not args.branches:
+        args.branches = list(project_lookup.values())
 
     skipfile = get_file(args.skipfile_url)
 
@@ -168,13 +196,11 @@ def run(raw_args=None):
             or "all" in reason["boards"]
         ):
             if reason["branches"] == "all" or "all" in reason["branches"]:
-                projects = [
-                    look_up_project_by_branch(branch) for branch in args.branches
-                ]
+                projects = [project_lookup[branch] for branch in args.branches]
             else:
                 for branch_name in reason["branches"]:
                     if branch_name in args.branches:
-                        projects.append(look_up_project_by_branch(branch_name))
+                        projects.append(project_lookup[branch_name])
                     else:
                         logger.debug(
                             f"Branch name {branch_name} is not supported by this script or was not provided as an argument in --branches. Skipping."
@@ -192,7 +218,7 @@ def run(raw_args=None):
 
             reason_list.append(cleaned_reason)
 
-    for project in [look_up_project_by_branch(project) for project in args.branches]:
+    for project in [project_lookup[project] for project in args.branches]:
         reproducer_script_name = f"skipfile-reproducer-{args.group}-{project}"
         if Path(reproducer_script_name).exists():
             Path.unlink(Path(reproducer_script_name))

--- a/squad-generate-rc-branches
+++ b/squad-generate-rc-branches
@@ -8,20 +8,24 @@
 
 
 from argparse import ArgumentParser
+from logging import DEBUG, INFO, basicConfig, getLogger
 from os import getenv
 from sys import exit
 
 from squad_client.core.api import SquadApi
 
-from squadutilslib import get_recent_projects
+from squadutilslib import get_recent_branches
 
 squad_host_url = "https://qa-reports.linaro.org/"
 SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
 
+basicConfig(level=INFO)
+logger = getLogger(__name__)
+
 
 def parse_args(raw_args):
     parser = ArgumentParser(
-        description="Get the projects that were pushed to for a SQUAD group over a given period"
+        description="Get the branches that were pushed to for a SQUAD group over a given number of days."
     )
 
     parser.add_argument(
@@ -32,7 +36,8 @@ def parse_args(raw_args):
 
     parser.add_argument(
         "--days",
-        required=True,
+        required=False,
+        default=7,
         type=int,
         help="The number of days to look back.",
     )
@@ -62,14 +67,17 @@ def parse_args(raw_args):
 
 
 def run(raw_args=None):
-    args = parse_args(raw_args=None)
+    args = parse_args(raw_args)
+    if args.debug:
+        logger.setLevel(level=DEBUG)
 
-    recent_projects = get_recent_projects(
+    recent_projects = get_recent_branches(
         args.group, args.days, args.must_contain, args.must_not_contain, args.debug
     )
-    for project in recent_projects.values():
-        print(f"skipfile-reproducer-lkft-{project}-plan.yaml")
-    return 0
+
+    # Print the branch for each project
+    for branch in recent_projects.values():
+        print(f"{branch}")
 
 
 if __name__ == "__main__":

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -36,7 +36,7 @@ def get_file(path, filename=None):
     downloaded file. If an existing file path is passed in, return the path. If
     a non-existent path is passed in, raise an exception.
     """
-    logger.info(f"Getting file from {path}")
+    logger.debug(f"Getting file from {path}")
     if search(r"https?://", path):
         request = get(path, allow_redirects=True)
         request.raise_for_status()
@@ -76,9 +76,9 @@ def find_first_good_testrun(
         # Only pick builds that are finished, unless we specify that unfinished
         # builds are allowed
         if not build.finished and not allow_unfinished:
-            logger.info(f"Skipping {build.id} as build is not marked finished")
+            logger.debug(f"Skipping {build.id} as build is not marked finished")
             continue
-        logger.info(f"Checking build {build.id}")
+        logger.debug(f"Checking build {build.id}")
         # Create the list of suite IDs from the suite names
         if suite_names:
             for s in suite_names:
@@ -167,7 +167,7 @@ def get_reproducer(
 
     # Get the reproducer if a testrun is found
     if testrun:
-        logger.info(
+        logger.debug(
             f"Found testrun {testrun} with build_name {testrun.metadata.build_name}, url: {testrun.url}"
         )
 

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -177,15 +177,17 @@ def get_reproducer(
 
         try:
             if local:
-                tuxrun = get_file(f"{testrun.job_url}/reproducer", filename=filename)
+                reproducer = get_file(
+                    f"{testrun.job_url}/reproducer", filename=filename
+                )
             else:
-                tuxrun = get_file(
+                reproducer = get_file(
                     f"{testrun.job_url}/tuxsuite_reproducer", filename=filename
                 )
         except HTTPError:
             logger.error(f"Reproducer not found at {testrun.job_url}!")
             raise ReproducerNotFound
-        return tuxrun
+        return reproducer
     else:
         raise ReproducerNotFound
 

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -186,21 +186,19 @@ def get_reproducer(
         except HTTPError:
             logger.error(f"Reproducer not found at {testrun.job_url}!")
             raise ReproducerNotFound
-        return reproducer
+        return Path(reproducer).read_text(encoding="utf-8")
     else:
         raise ReproducerNotFound
 
 
-def create_custom_reproducer(
-    reproducer, suite, custom_commands, local=False, filename="reproducer"
-):
+def create_custom_reproducer(reproducer, suite, custom_commands, filename, local=False):
     """
     Given an existing TuxRun or TuxTest reproducer, edit this reproducer to run
     a given custom command.
     """
     build_cmdline = ""
 
-    for line in Path(reproducer).read_text(encoding="utf-8").split("\n"):
+    for line in reproducer.split("\n"):
         if ("tuxsuite test submit" in line and not local) or (
             "tuxrun --runtime" in line and local
         ):
@@ -224,4 +222,4 @@ def create_custom_reproducer(
     reproducer_list = f"""#!/bin/bash\n{build_cmdline}"""
     Path(filename).write_text(reproducer_list, encoding="utf-8")
 
-    return filename
+    return Path(filename).read_text(encoding="utf-8")

--- a/squadutilslib.py
+++ b/squadutilslib.py
@@ -223,3 +223,7 @@ def create_custom_reproducer(reproducer, suite, custom_commands, filename, local
     Path(filename).write_text(reproducer_list, encoding="utf-8")
 
     return Path(filename).read_text(encoding="utf-8")
+
+
+def create_ltp_custom_command(tests):
+    return f"cd /opt/ltp && ./runltp -s {' '.join(tests)}"


### PR DESCRIPTION
Looking for feedback on code for automatically identifying recent branch names.

The current `get_recent_branches` code in `squadutilslib` searches through all the projects within a group, looking for the last build that contains a git_ref (for the branch name) and was run within a specified period of days.

An example command to launch the wrapper script:
```
 ./squad-generate-rc-branches --group lkft --days 7 --debug
```

I hit a couple of problems when drafting this code:
- Mainline and next have different naming conventions than the other branches - perhaps these should be hard-coded still rather than looked up
- Not all builds contain a git ref in the metadata (used to read the branch name), so I have to look back until I find a build which has one
- I was having issues ordering the projects by how recently they were pushed to - this appeared to be an issue when I was searching using `squad-client-utils` but not when I was using the SQUAD API through the web view. Not being able to order them in this way meant I have to search through all the projects which is slow.
- There are quite a few projects lying around like `sanity` versions of projects which we presumably want to drop (so I added parameters `must_contain` and `must_not_contain` to allow this filtering)

Current usage:
```
./squad-generate-rc-branches -h
usage: squad-generate-rc-branches [-h] --group GROUP [--days DAYS] [--must-not-contain MUST_NOT_CONTAIN] [--must-contain MUST_CONTAIN] [--debug]

Get the branches that were pushed to for a SQUAD group over a given number of days.

options:
  -h, --help            show this help message and exit
  --group GROUP         The name of the SQUAD group.
  --days DAYS           The number of days to look back.
  --must-not-contain MUST_NOT_CONTAIN
                        Ignore project names that contain any of these terms.
  --must-contain MUST_CONTAIN
                        Project names must contain one of these terms.
  --debug               Display debug messages.
```
Any feedback would be helpful.