### PR TITLE
Fix base patch name

### DIFF
--- a/read-skipfile-results
+++ b/read-skipfile-results
@@ -218,7 +218,7 @@ def run(raw_args=None):
     github_repo = g.get_repo(f"{username}/{repo_name}")
 
     # Base patch - base patch for PRs
-    base_patch = "origin/master"
+    base_patch = "master"
 
     # If there are any formatting updates, make these
     if repo.index.diff("HEAD"):


### PR DESCRIPTION
- Fix the name of the base patch for PRs, which was incorrectly set to "origin/master" instead of "master" in the case where there are no formatting changes required in the skipfile
- ~~Rename the variables for holding the base patch info so it is easier to differentiate them and understand their purpose.~~ - moved to https://github.com/Linaro/squad-client-utils/pull/32