### PR TITLE
Add support for download reproducers by TestRun ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ options:
                         The number of builds to fetch when searching for a reproducer.
 ```
 
+### `squad-create-reproducer-from-testrun`: Get a reproducer for a given TestRun ID.
+
+This script fetches the build or test reproducer for a given TestRun ID.
+
+```
+usage: squad-create-reproducer-from-testrun [-h] --testrun TESTRUN [--debug]
+                                            [--filename FILENAME] [--local]
+
+Provide a SQUAD TestRun ID to download the build or test reproducer for that TestRun. The
+reproducer will be printed to the terminal and written to a file.
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --testrun TESTRUN    The TestRun ID of the build or test to fetch the reproducer for.
+  --debug              Display debug messages.
+  --filename FILENAME  Name for the reproducer file, 'reproducer' by default.
+  --local              Fetch a TuxRun or TuxMake reproducer rather than a TuxPlan reproducer.
+```
+
 ### `squad-create-skipfile-reproducers`: Creating skipfile reproducers
 
 The `squad-create-skipfile-reproducers` script can be used to create TuxRun or

--- a/squad-create-reproducer-from-testrun
+++ b/squad-create-reproducer-from-testrun
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim: set ts=4
+#
+# Copyright 2023-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+
+from argparse import ArgumentParser
+from logging import INFO, basicConfig, getLogger
+from os import chmod, getenv
+from stat import S_IRUSR, S_IWUSR, S_IXUSR
+from sys import exit
+
+from squad_client.core.api import SquadApi
+
+from squadutilslib import (
+    ReproducerNotFound,
+    get_reproducer_from_testrun,
+)
+
+squad_host_url = "https://qa-reports.linaro.org/"
+SquadApi.configure(cache=3600, url=getenv("SQUAD_HOST", squad_host_url))
+
+basicConfig(level=INFO)
+logger = getLogger(__name__)
+
+
+def parse_args(raw_args):
+    parser = ArgumentParser(
+        description="Provide a SQUAD TestRun ID to download the build or test reproducer for that TestRun."
+        + " The reproducer will be printed to the terminal and written to a file."
+    )
+
+    parser.add_argument(
+        "--testrun",
+        required=True,
+        help="The TestRun ID of the build or test to fetch the reproducer for.",
+    )
+
+    # Optional arguments:
+    parser.add_argument(
+        "--debug",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Display debug messages.",
+    )
+
+    parser.add_argument(
+        "--filename",
+        required=False,
+        help="Name for the reproducer file, 'reproducer' by default.",
+    )
+
+    parser.add_argument(
+        "--local",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Fetch a TuxRun or TuxMake reproducer rather than a TuxPlan reproducer.",
+    )
+
+    return parser.parse_args(raw_args)
+
+
+def run(raw_args=None):
+    args = parse_args(raw_args)
+
+    # If filename was not provided, set filename to "reproducer"
+    if not args.filename:
+        filename = "reproducer"
+    else:
+        filename = args.filename
+
+    try:
+        reproducer = get_reproducer_from_testrun(args.testrun, filename, args.local)
+
+    except ReproducerNotFound as e:
+        logger.error(f"No reproducer could be found for TestRun {args.testrun}")
+        logger.error(f"{e}")
+        return -1
+
+    # If a filename was provided, don't print the reproducer to console
+    if not args.filename:
+        print(reproducer)
+
+    if args.local:
+        # Make the script executable
+        chmod(filename, S_IXUSR | S_IRUSR | S_IWUSR)
+
+    logger.info(f"file created: {filename}")
+
+
+if __name__ == "__main__":
+    exit(run())


### PR DESCRIPTION
Add support in squadutilslib and squad-create-reproducer for downloading the build or test reproducer by TestRun ID as an alternative to searching for the latest test reproducer in a given group and project.