### PR TITLE
add squad-show-jobs

### DIFF
--- a/squad-show-or-cancel-jobs
+++ b/squad-show-or-cancel-jobs
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# vim: set ts=4
+#
+# Copyright 2024-present Linaro Limited
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+import logging
+import sys
+from squad_client.core.api import SquadApi
+from squad_client.core.models import Squad
+from datetime import datetime
+from datetime import timedelta
+
+SquadApi.configure(cache=3600, url="https://qa-reports.linaro.org/")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def arg_parser():
+    parser = argparse.ArgumentParser(description="Show's jobs that is not fetched.")
+
+    parser.add_argument(
+        "--group",
+        required=True,
+        help="squad group",
+    )
+
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="squad project",
+    )
+
+    parser.add_argument(
+        "--days",
+        required=False,
+        default=10,
+        help="environment",
+    )
+
+    parser.add_argument(
+        "--job-status",
+        required=False,
+        default="Submitted, Scheduled, Running",
+        help="Job status separated by comma ','. The job status can be, 'Submitted, Scheduled, Running",
+    )
+
+    parser.add_argument(
+        "--environments",
+        required=False,
+        default="",
+        help="Environments separated by comma ','",
+    )
+
+    parser.add_argument(
+        "--cancel",
+        action="store_true",
+        default=False,
+        help="Cancel jobs",
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Display debug messages",
+    )
+
+    return parser
+
+
+def run():
+    args = arg_parser().parse_args()
+    if args.debug:
+        logger.setLevel(level=logging.DEBUG)
+
+    group = Squad().group(args.group)
+    if group is None:
+        logger.error(f"Get group failed. Group not found: '{args.group}'.")
+        return -1
+
+    project = group.project(args.project)
+    if project is None:
+        logger.error(f"Get project failed. Project not found: '{args.project}'.")
+        return -1
+
+    n_days_ago = str(datetime.now() - timedelta(days=int(args.days))).replace(" ", "T")
+    jobs = Squad().testjobs(
+        target__id=project.id,
+        fetched=False,
+        created_at__lt=n_days_ago,
+        count=500,
+        job_status__in=args.job_status,
+        ordering="-id",
+        environment__in=args.environments,
+    ).values()
+    for j in jobs:
+        print(f"{j.id} : {j.external_url} : {j.job_status}, {j.created_at}, {j.environment}")
+        if args.cancel:
+            print("NOTE: LAVA jobs might take a few minutes to show up as canceled in SQUAD")
+            j.cancel()
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
This script show jobs that isn't fetched, that has job status 'Running', 'Scheduled' or 'Submitted'.
With this script its possible to cancel any of the jobs with that status. Filtering can be done by group, project, environment, job status and days. Days will list all jobs older than today - X days back, default 10.