### PR TITLE
Ensure virtual environments

### DIFF
--- a/squad-compare-builds
+++ b/squad-compare-builds
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: set ts=4
 #

--- a/squad-get-testlog
+++ b/squad-get-testlog
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import requests
 import json
 import sys

--- a/squad-local-bisect
+++ b/squad-local-bisect
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: set ts=4
 #


### PR DESCRIPTION
As python supports virtual environments, using /usr/bin/env python will make sure that your scripts runs inside the virtual environment, if you are inside one. Whereas, /usr/bin/python will run outside the virtual environment.