### PR TITLE
squad-show-or-cancel-jobs: job-status: default drop spaces

### DIFF
--- a/squad-show-or-cancel-jobs
+++ b/squad-show-or-cancel-jobs
@@ -44,7 +44,7 @@ def arg_parser():
     parser.add_argument(
         "--job-status",
         required=False,
-        default="Submitted, Scheduled, Running",
+        default="Submitted,Scheduled,Running",
         help="Job status separated by comma ','. The job status can be, 'Submitted, Scheduled, Running",
     )
 


### PR DESCRIPTION
Drop the spaces in the default list, since that reads better as a list.